### PR TITLE
Backport PHPMailer/PHPMailer#2188 Always use CRLF if php version is 8.0 or newer

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1462,7 +1462,7 @@ class PHPMailer
     {
         if (
             'smtp' === $this->Mailer
-            || ('mail' === $this->Mailer && stripos(PHP_OS, 'WIN') === 0)
+            || ('mail' === $this->Mailer && (PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0)
         ) {
             //SMTP mandates RFC-compliant line endings
             //and it's also used with mail() on Windows


### PR DESCRIPTION
full back port of https://github.com/PHPMailer/PHPMailer/pull/2188 needed so Joomla mail() command can work 

Closes https://github.com/joomla/joomla-cms/issues/32830 when released and composer.json updated in Joomla `staging`

// cc @OctavianC @zero-24