### PR TITLE
Backported PHP8 fix, concept from PHPMailer/PHPMailer#2188

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -687,6 +687,12 @@ class PHPMailer
      */
     private function mailPassthru($to, $subject, $body, $header, $params)
     {
+        // Joomla Backported concept from https://github.com/PHPMailer/PHPMailer/pull/2188
+        if (PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0)
+        {
+            $header = str_replace("\n", self::CRLF, $header);
+        }
+        
         //Check overloading of mail function to avoid double-encoding
         if (ini_get('mbstring.func_overload') & 1) {
             $subject = $this->secureHeader($subject);


### PR DESCRIPTION
 Backported concept from https://github.com/PHPMailer/PHPMailer/pull/2188 with a light touch approach

replacement for https://github.com/joomla-backports/PHPMailer/pull/1


Closes joomla/joomla-cms#32830 when released and composer.json updated in Joomla staging

// cc @OctavianC @zero-24